### PR TITLE
Release/6.0.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,8 +22,8 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '15.4.0'
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: /Users/runner/Library/Developer/Xcode/DerivedData
         key: ${{ runner.os }}-spm-examples-${{ hashFiles('**/Package.resolved') }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Segment",
-        "repositoryURL": "https://github.com/segmentio/analytics-swift.git",
+        "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "f6f3a7fafcace7bcdbda329f9b309f31bf9a42a1",
-          "version": "1.5.11"
+          "revision": "5d3a762da5412d324205a58358b95e1da334c21e",
+          "version": "1.8.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Survicate/survicate-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "bd013377f640cfc76907205317c09c49ab2e5833",
-          "version": "5.0.0"
+          "revision": "7beca9a041a385619e8dc87e421718c46c048045",
+          "version": "6.3.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SurvicateDestination",
     platforms: [
-        .iOS("13.0"),
+        .iOS("14.0"),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(
             name: "Survicate",
             url: "https://github.com/Survicate/survicate-ios-sdk",
-            from: "5.0.0"
+            from: "6.3.4"
         )
     ],
     targets: [
@@ -38,4 +38,3 @@ let package = Package(
         // TESTS ARE HANDLED VIA THE EXAMPLE APP.
     ]
 )
-

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(
             name: "Survicate",
             url: "https://github.com/Survicate/survicate-ios-sdk",
-            from: "6.3.4"
+            from: "6.0.0"
         )
     ],
     targets: [

--- a/Sources/SurvicateDestination/Version.swift
+++ b/Sources/SurvicateDestination/Version.swift
@@ -13,4 +13,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __destination_version = "6.0.0"
+internal let __destination_version = "6.0.1"


### PR DESCRIPTION
- Bump version of the Survicate iOS SDK to 6.0.0
- Update min deployment target to iOS 14 (required by Survicate SDK since version 6.0.0)