### PR TITLE
Fix retain cycle in Segment plugin (contribution by @rrolland, MIT License)

### DIFF
--- a/Sources/SurvicateDestination/SurvicateDestination.swift
+++ b/Sources/SurvicateDestination/SurvicateDestination.swift
@@ -14,7 +14,7 @@ public class SurvicateDestination: DestinationPlugin {
     public let type = PluginType.destination
 
     public let key = "Survicate"
-    public var analytics: Analytics? = nil
+    public weak var analytics: Analytics? = nil
     
     private var SurvicateSettings: SurvicateSettings?
         


### PR DESCRIPTION
When using the Survicate plugin, we have noticed a retain cycle issue on the Analytics instance.

This issue is fixed by using a weak reference for the analytics instance.