### PR TITLE
Release/8.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Survicate/survicate-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "0e82173f268c5bae5cf3956baa766e930ed6608c",
-          "version": "8.0.0"
+          "revision": "b3d93d13b027fbc3a5c4864fab4ab7ecc9685703",
+          "version": "7.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Survicate/survicate-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "b3d93d13b027fbc3a5c4864fab4ab7ecc9685703",
-          "version": "7.0.0"
+          "revision": "0e82173f268c5bae5cf3956baa766e930ed6608c",
+          "version": "8.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SurvicateDestination",
     platforms: [
-        .iOS("14.0"),
+        .iOS("15.0"),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -25,7 +25,7 @@ let package = Package(
         .package(
             name: "Survicate",
             url: "https://github.com/Survicate/survicate-ios-sdk",
-            from: "7.0.0"
+            from: "8.0.0"
         )
     ],
     targets: [

--- a/Sources/SurvicateDestination/SurvicateDestination.swift
+++ b/Sources/SurvicateDestination/SurvicateDestination.swift
@@ -45,7 +45,7 @@ public class SurvicateDestination: DestinationPlugin {
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {
-        let userId = event.userId ?? ""
+        let userId = event.userId ?? analytics?.userId ?? ""
         SurvicateSdk.shared.setUserTrait(withName: USER_ID_KEY, value: userId)
 
         if let dictionary = event.traits?.dictionaryValue {

--- a/Sources/SurvicateDestination/SurvicateDestination.swift
+++ b/Sources/SurvicateDestination/SurvicateDestination.swift
@@ -45,7 +45,7 @@ public class SurvicateDestination: DestinationPlugin {
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {
-        let userId = event.userId ?? analytics?.userId ?? ""
+        let userId = event.userId ?? ""
         SurvicateSdk.shared.setUserTrait(withName: USER_ID_KEY, value: userId)
 
         if let dictionary = event.traits?.dictionaryValue {

--- a/Sources/SurvicateDestination/SurvicateDestination.swift
+++ b/Sources/SurvicateDestination/SurvicateDestination.swift
@@ -45,9 +45,8 @@ public class SurvicateDestination: DestinationPlugin {
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {
-        if let userId = event.userId {
-            SurvicateSdk.shared.setUserTrait(withName: USER_ID_KEY, value: userId)
-        }
+        let userId = event.userId ?? ""
+        SurvicateSdk.shared.setUserTrait(withName: USER_ID_KEY, value: userId)
 
         if let dictionary = event.traits?.dictionaryValue {
             let traits: [UserTrait] = dictionary.compactMap { key, value in

--- a/Sources/SurvicateDestination/Version.swift
+++ b/Sources/SurvicateDestination/Version.swift
@@ -13,4 +13,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __destination_version = "7.0.0"
+internal let __destination_version = "8.0.0"


### PR DESCRIPTION
Bump Survicate iOS SDK dependency to 8.0.0

- Update Survicate SDK dependency from 7.0.0 to 8.0.0
- Bump iOS minimum deployment target from 14.0 to 15.0
- Bump internal destination version to 8.0.0
- Always set `user_id` trait in `identify()` — default to empty string `""` when userId is nil, instead of skipping